### PR TITLE
Update m5stack-papers3.yaml with programmatic power functionality

### DIFF
--- a/m5stack-papers3.yaml
+++ b/m5stack-papers3.yaml
@@ -210,6 +210,25 @@ binary_sensor:
     name: "Charge Status"
     device_class: battery_charging
 
+# switch:
+#   - platform: gpio
+#     pin: GPIO44
+#     id: gpio_power
+#
+# script:
+#   - id: power_off
+#     then:
+#       - repeat: 
+#           count: 10 # M5 docs execute 5 full on/off cycles for the M5PaperS3, hence 10 toggles of the pin.
+#           then: 
+#             - switch.toggle: gpio_power
+#             - delay: 50ms
+#
+# Usage: Execute the script in an action where appropriate (eg on_idle)
+#
+# on_...:
+#   then:
+#     - script.execute: power_off
 
 time:
   - platform: pcf8563  #BM8563


### PR DESCRIPTION
I was looking at m5's unified library and noticed that the M5PaperS3 has a quirky power down function, so I copied it here into this config since I found this config immensely helpful in getting my M5PaperS3 working on ESPHome.